### PR TITLE
Fix issue with range min

### DIFF
--- a/presenters/form/controls/range-slider.js
+++ b/presenters/form/controls/range-slider.js
@@ -259,7 +259,7 @@ customElements.define('range-slider', class extends LitElement{
     }
 
     get _len(){ return this.max - this.min }
-    get _minLeft(){ return (this.valMin) / this._len * 100 }
+    get _minLeft(){ return (this.valMin - this.min) / this._len * 100 }
     get _maxLeft(){ return (this.valMax - this.min) / this._len * 100 }
     get _trackLength(){ return this._maxLeft - this._minLeft }
 


### PR DESCRIPTION
This fixes an issue with range sliders that have non-zero minimums. The issue was partially solved by https://github.com/kjantzer/bui/commit/ad974ac753a445c68b468c41d07f25795903ba69 but only the `_maxLeft` was taken into account, and not the `_minLeft` which means the max slider behaves, but the min slider does not.

This can be tested by setting a large min/max such as:

    <range-slider range min="500" max="1500" .values=${[800, 1200]}>